### PR TITLE
Add support for named child routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ A route object under the default matching algorithm and route element resolver c
 - `Component` or `getComponent`: the component for the route, or a method that returns the component for the route
 - `data` or `getData`: additional data for the route, or a method that returns additional data for the route
 - `render`: a method that returns the element for the route
-- `children`: an array of child route objects; if using JSX configuration components, this comes from the JSX children
+- `children`: an array of child route objects, or an object of those arrays; if using JSX configuration components, this comes from the JSX children
 
 A route configuration consists of an array of route objects. You can generate such an array of route objects from JSX with `<Route>` elements using `makeRouteConfig`.
 
@@ -352,6 +352,95 @@ function render({ Component, props }) {
 ```
 
 If any matched routes have unresolved asynchronous component or data dependencies, the router will initially attempt to render all such routes in their loading state. If those routes all implement `render` methods and return non-`undefined` values from their `render` methods, the router will render the matched routes in their loading states. Otherwise, the router will continue to render the previous set of routes until all asynchronous dependencies resolve.
+
+#### Named child routes
+
+Specify an object for the `children` property on a route to set up named child routes. A route with named child routes will match only if every route group matches. The elements corresponding to the child routes will be available on their parent as props with the same name as the route groups.
+
+```js
+function AppPage({ nav, main }) {
+  return (
+    <div className="app">
+      <div className="nav">
+        {nav}
+      </div>
+      <div className="main">
+        {main}
+      </div>
+    </div>
+  );
+}
+
+const route = {
+  path: '/',
+  Component: AppPage,
+  children: [
+    {
+      path: 'foo',
+      children: {
+        nav: [
+          {
+            path: '(.*)?',
+            Component: FooNav,
+          },
+        ],
+        main: [
+          {
+            path: 'a',
+            Component: FooA,
+          },
+          {
+            path: 'b',
+            Component: FooB,
+          },
+        ],
+      },
+    },
+    {
+      path: 'bar',
+      children: {
+        nav: [
+          {
+            path: '(.*)?',
+            Component: BarNav,
+          },
+        ],
+        main: [
+          {
+            Component: BarMain,
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const jsxRoute = (
+  <Route path="/" Component={AppPage}>
+    <Route path="foo">
+      {{
+        nav: (
+          <Route path="(.*)?" Component={FooNav} />
+        ),
+        main: [
+          <Route path="a" Component={FooA} />,
+          <Route path="b" Component={FooB} />,
+        ],
+      }}
+    </Route>
+    <Route path="bar">
+      {{
+        nav: (
+          <Route path="(.*)?" Component={BarNav} />
+        ),
+        main: (
+          <Route Component={BarMain} />
+        ),
+      }}
+    </Route>
+  </Route>
+);
+```
 
 #### Redirects
 

--- a/src/ElementsRenderer.js
+++ b/src/ElementsRenderer.js
@@ -3,13 +3,32 @@ import React from 'react';
 
 const propTypes = {
   elements: PropTypes.arrayOf(
+    // This should be an object of this same type, but recursive checks would
+    // probably be too messy.
+    PropTypes.object,
     PropTypes.element,
   ).isRequired,
 };
 
 function accumulateElement(children, element) {
-  if (!element || !children) {
-    return element || children;
+  if (!children) {
+    return element;
+  }
+
+  if (!element) {
+    return children;
+  }
+
+  if (!React.isValidElement(children)) {
+    // Children come from named child routes.
+    const groups = {};
+    Object.entries(children).forEach(([groupName, groupElements]) => {
+      groups[groupName] = groupElements.reduceRight(
+        accumulateElement, null,
+      );
+    });
+
+    return React.cloneElement(element, groups);
   }
 
   return React.cloneElement(element, { children });

--- a/src/Matcher.js
+++ b/src/Matcher.js
@@ -22,17 +22,7 @@ export default class Matcher {
       return null;
     }
 
-    const routeIndices = new Array(matches.length);
-    const routeParams = new Array(matches.length);
-    const params = {};
-
-    matches.forEach((routeMatch, i) => {
-      routeIndices[i] = routeMatch.index;
-      routeParams[i] = routeMatch.params;
-      Object.assign(params, routeMatch.params);
-    });
-
-    return { routeIndices, routeParams, params };
+    return this.makePayload(matches);
   }
 
   getRoutes({ routeIndices }) {
@@ -40,13 +30,7 @@ export default class Matcher {
       return null;
     }
 
-    let lastRouteConfig = this.routeConfig;
-
-    return routeIndices.map((routeIndex) => {
-      const route = lastRouteConfig[routeIndex];
-      lastRouteConfig = route.children;
-      return route;
-    });
+    return this.getRoutesFromIndices(routeIndices, this.routeConfig);
   }
 
   joinPaths(basePath, path) {
@@ -86,12 +70,21 @@ export default class Matcher {
         continue; // eslint-disable-line no-continue
       }
 
-      const { children = [] } = route;
       const { params, remaining } = match;
+      const { children } = route;
 
-      const childMatches = this.matchRoutes(children, remaining);
-      if (childMatches) {
-        return [{ index, params }, ...childMatches];
+      if (children) {
+        if (Array.isArray(children)) {
+          const childMatches = this.matchRoutes(children, remaining);
+          if (childMatches) {
+            return [{ index, params }, ...childMatches];
+          }
+        } else {
+          const groups = this.matchGroups(children, remaining);
+          if (groups) {
+            return [{ index, params }, { groups }];
+          }
+        }
       }
 
       if (!remaining) {
@@ -133,6 +126,104 @@ export default class Matcher {
 
   getCanonicalPattern(pattern) {
     return pattern.charAt(0) === '/' ? pattern : `/${pattern}`;
+  }
+
+  matchGroups(routeGroups, pathname) {
+    const groups = {};
+
+    for (const [groupName, routes] of Object.entries(routeGroups)) {
+      const groupMatch = this.matchRoutes(routes, pathname);
+      if (!groupMatch) {
+        return null;
+      }
+
+      groups[groupName] = groupMatch;
+    }
+
+    return groups;
+  }
+
+  makePayload(matches) {
+    const routeMatch = matches[0];
+
+    if (routeMatch.groups) {
+      warning(
+        matches.length === 1,
+        'Route match with groups %s has children, which are ignored.',
+        Object.keys(routeMatch.groups).join(', '),
+      );
+
+      const routeIndices = {};
+      const routeParams = [];
+      const params = {};
+
+      Object.entries(
+        routeMatch.groups,
+      ).forEach(([groupName, groupMatches]) => {
+        const groupPayload = this.makePayload(groupMatches);
+
+        // Retain the nested group structure for route indices so we can
+        // reconstruct the element tree from flattened route elements.
+        routeIndices[groupName] = groupPayload.routeIndices;
+
+        // Flatten route groups for route params matching getRoutesFromIndices
+        // below.
+        routeParams.push(...groupPayload.routeParams);
+
+        // Just merge all the params depth-first; it's the easiest option.
+        Object.assign(params, groupPayload.params);
+      });
+
+      return { routeIndices, routeParams, params };
+    }
+
+    const { index, params } = routeMatch;
+
+    if (matches.length === 1) {
+      return {
+        routeIndices: [index],
+        routeParams: [params],
+        params,
+      };
+    }
+
+    const childPayload = this.makePayload(matches.slice(1));
+    return {
+      routeIndices: [index, ...childPayload.routeIndices],
+      routeParams: [params, ...childPayload.routeParams],
+      params: { ...params, ...childPayload.params },
+    };
+  }
+
+  getRoutesFromIndices(routeIndices, routeConfigOrGroups) {
+    const routeIndex = routeIndices[0];
+
+    if (typeof routeIndex === 'object') {
+      // Flatten route groups to save resolvers from having to explicitly
+      // handle them.
+      const groupRoutes = [];
+      Object.entries(routeIndex).forEach(([groupName, groupRouteIndices]) => {
+        groupRoutes.push(...this.getRoutesFromIndices(
+          groupRouteIndices, routeConfigOrGroups[groupName],
+        ));
+      });
+
+      return groupRoutes;
+    }
+
+    const route = routeConfigOrGroups[routeIndex];
+
+    if (routeIndices.length === 1) {
+      return [route];
+    }
+
+    return [
+      route,
+      ...this.getRoutesFromIndices(
+        routeIndices.slice(1),
+        route.children,
+      ),
+    ];
   }
 
   isPathnameActive(matchPathname, pathname, exact) {

--- a/src/makeRouteConfig.js
+++ b/src/makeRouteConfig.js
@@ -10,7 +10,16 @@ export default function makeRouteConfig(node) {
       const route = new Type(props);
 
       if (children) {
-        route.children = makeRouteConfig(children);
+        if (React.isValidElement(children) || Array.isArray(children)) {
+          route.children = makeRouteConfig(children);
+        } else {
+          const routeGroups = {};
+          Object.entries(children).forEach(([groupName, groupRoutes]) => {
+            routeGroups[groupName] = makeRouteConfig(groupRoutes);
+          });
+
+          route.children = routeGroups;
+        }
       }
 
       return route;

--- a/src/utils/resolveRenderArgs.js
+++ b/src/utils/resolveRenderArgs.js
@@ -1,5 +1,30 @@
 import HttpError from '../HttpError';
 
+function foldElements(elementsRaw, routeIndices) {
+  const elements = [];
+
+  for (const routeIndex of routeIndices) {
+    if (typeof routeIndex === 'object') {
+      // Reshape the next elements in the elements array to match the nested
+      // tree structure corresponding to the route groups.
+      const groupElements = {};
+      Object.entries(routeIndex).forEach(([groupName, groupRouteIndices]) => {
+        groupElements[groupName] = foldElements(
+          elementsRaw, groupRouteIndices,
+        );
+      });
+
+      elements.push(groupElements);
+    } else {
+      // We intentionally modify elementsRaw, to make it easier to recursively
+      // handle groups.
+      elements.push(elementsRaw.shift());
+    }
+  }
+
+  return elements;
+}
+
 export default async function* resolveRenderArgs({
   router, match, matchContext, resolver,
 }) {
@@ -21,7 +46,10 @@ export default async function* resolveRenderArgs({
 
   try {
     for await (const elements of resolver.resolveElements(augmentedMatch)) {
-      yield { ...augmentedMatch, elements };
+      yield {
+        ...augmentedMatch,
+        elements: foldElements([...elements], match.routeIndices),
+      };
     }
   } catch (e) {
     if (e instanceof HttpError) {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,6 +5,7 @@
   "rules": {
     "import/no-extraneous-dependencies": [2, {
       "devDependencies": true
-    }]
+    }],
+    "react/prop-types": "off"
   }
 }

--- a/test/ElementsRenderer.test.js
+++ b/test/ElementsRenderer.test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import ElementsRenderer from '../src/ElementsRenderer';
@@ -23,7 +22,6 @@ describe('<ElementsRenderer>', () => {
 
   it('should render elements with nested structure', () => {
     const Parent = ({ children }) => <div className="parent">{children}</div>;
-    Parent.propTypes = { children: PropTypes.element };
     const Child = () => <div className="child" />;
 
     const elements = [<Parent />, <Child />];

--- a/test/makeRouteConfig.test.js
+++ b/test/makeRouteConfig.test.js
@@ -4,12 +4,19 @@ import makeRouteConfig from '../src/makeRouteConfig';
 import Redirect from '../src/Redirect';
 import Route from '../src/Route';
 
-const AppPage = () => {};
-const MainPage = () => {};
-const FooPage = () => {};
-const BarPage = () => {};
-
 describe('makeRouteConfig', () => {
+  const AppPage = () => {};
+
+  const MainPage = () => {};
+  const FooPage = () => {};
+  const BarPage = () => {};
+
+  const FooNav = () => {};
+  const FooA = () => {};
+  const FooB = () => {};
+  const BarNav = () => {};
+  const BarMain = () => {};
+
   it('should work with a route', () => {
     expect(makeRouteConfig(
       <Route path="/" Component={AppPage} />,
@@ -75,5 +82,75 @@ describe('makeRouteConfig', () => {
         ],
       }),
     ]);
+  });
+
+  it('should work with named child routes', () => {
+    expect(makeRouteConfig(
+      <Route path="/" Component={AppPage}>
+        <Route path="foo">
+          {{
+            nav: (
+              <Route path="(.*)?" Component={FooNav} />
+            ),
+            main: [
+              <Route path="a" Component={FooA} />,
+              <Route path="b" Component={FooB} />,
+            ],
+          }}
+        </Route>
+        <Route path="bar">
+          {{
+            nav: (
+              <Route path="(.*)?" Component={BarNav} />
+            ),
+            main: (
+              <Route Component={BarMain} />
+            ),
+          }}
+        </Route>
+      </Route>,
+    )).toEqual([{
+      path: '/',
+      Component: AppPage,
+      children: [
+        {
+          path: 'foo',
+          children: {
+            nav: [
+              {
+                path: '(.*)?',
+                Component: FooNav,
+              },
+            ],
+            main: [
+              {
+                path: 'a',
+                Component: FooA,
+              },
+              {
+                path: 'b',
+                Component: FooB,
+              },
+            ],
+          },
+        },
+        {
+          path: 'bar',
+          children: {
+            nav: [
+              {
+                path: '(.*)?',
+                Component: BarNav,
+              },
+            ],
+            main: [
+              {
+                Component: BarMain,
+              },
+            ],
+          },
+        },
+      ],
+    }]);
   });
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import createRender from '../src/createRender';
+import getFarceResult from '../src/server/getFarceResult';
+
+async function render(url, routeConfig) {
+  const { element } = await getFarceResult({
+    url,
+    routeConfig,
+    render: createRender({}),
+  });
+
+  return ReactTestUtils.renderIntoDocument(element);
+}
+
+describe('render', () => {
+  it('should support nested routes', async () => {
+    const instance = await render(
+      '/foo/baz/a',
+      [
+        {
+          path: 'foo',
+          Component: ({ children }) => <div className="foo">{children}</div>,
+          children: [
+            {
+              path: 'bar',
+              Component: () => <div className="bar" />,
+            },
+            {
+              path: 'baz/:qux',
+              Component: ({ params }) => (
+                <div className="baz">{params.qux}</div>
+              ),
+            },
+          ],
+        },
+      ],
+    );
+
+    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'foo');
+    expect(
+      ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'bar'),
+    ).toHaveLength(0);
+
+    const bazNode = ReactTestUtils.findRenderedDOMComponentWithClass(
+      instance, 'baz',
+    );
+    expect(bazNode.textContent).toBe('a');
+  });
+
+  it('should support named child routes', async () => {
+    const instance = await render(
+      '/foo/bar/qux/a',
+      [
+        {
+          path: 'foo',
+          Component: ({ nav, main }) => (
+            <div className="foo">
+              {nav}
+              {main}
+            </div>
+          ),
+          children: [
+            {
+              path: 'bar',
+              children: {
+                nav: [
+                  {
+                    path: '(.*)?',
+                    Component: () => <div className="bar-nav" />,
+                  },
+                ],
+                main: [
+                  {
+                    path: 'baz',
+                    Component: () => <div className="baz" />,
+                  },
+                  {
+                    path: 'qux/:quux',
+                    Component: ({ params }) => (
+                      <div className="qux">{params.quux}</div>
+                    ),
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    );
+
+    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'foo');
+    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'bar-nav');
+
+    expect(
+      ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'baz'),
+    ).toHaveLength(0);
+
+    const quxNode = ReactTestUtils.findRenderedDOMComponentWithClass(
+      instance, 'qux',
+    );
+    expect(quxNode.textContent).toBe('a');
+  });
+});


### PR DESCRIPTION
Closes #55 

How does this look?

Docs forthcoming, but the tests mostly show how the code works (though the nav definitions are a bit flaky).

Found Relay will mostly work out-of-the-box, except the param accumulation can be made more correct (it should be group-aware, since subsequent elements in the route array are now no longer always children).