### PR TITLE
Fix #159

### DIFF
--- a/src/Matcher.js
+++ b/src/Matcher.js
@@ -104,7 +104,7 @@ export default class Matcher {
     }
 
     const pattern = this.getCanonicalPattern(routePath);
-    let keys = [];
+    const keys = [];
     const regexp = pathToRegexp(pattern, keys, { end: false });
 
     const match = regexp.exec(pathname);

--- a/src/Matcher.js
+++ b/src/Matcher.js
@@ -104,7 +104,8 @@ export default class Matcher {
     }
 
     const pattern = this.getCanonicalPattern(routePath);
-    const regexp = pathToRegexp(pattern, { end: false });
+    let keys = [];
+    const regexp = pathToRegexp(pattern, keys, { end: false });
 
     const match = regexp.exec(pathname);
     if (match === null) {
@@ -112,7 +113,7 @@ export default class Matcher {
     }
 
     const params = Object.create(null);
-    regexp.keys.forEach(({ name }, index) => {
+    keys.forEach(({ name }, index) => {
       const value = match[index + 1];
       params[name] = value && decodeURIComponent(value);
     });


### PR DESCRIPTION
Fix #159 
Use the keys-array option which is available in all versions of path-to-regexp instead of the deprecated `keys` field. 