### PR TITLE
matcher should be class to allow proper import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,10 @@ declare module 'found' {
   }
 
   class Matcher implements Matcher {
-    constructor(routeConfig: RouteConfig);
+    constructor(
+      routeConfig: RouteConfig,
+      options?: { matchStemRoutes?: boolean },
+    );
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,10 @@ declare module 'found' {
     format: (pattern: any, params: ObjectMap) => any;
   }
 
+  class Matcher implements Matcher {
+    constructor(routeConfig: RouteConfig);
+  }
+
   /**
    * Location descriptor object used in #push and #replace.
    */


### PR DESCRIPTION
Hey guys, we've been using Found for some time and have some code in our network layer that uses the exported `Matcher` to create a match enhancer under certain circumstances. I'm super excited to see that you're now shipping Found with types, but the import of Matcher isn't working properly because the types don't declare it as a class.

This simple fix should solve it, but let me know if you need anything further.

_If at all possible, I'd appreciate a quick merge here; I had to fork in the meantime_

For reference, here's where we're using the Matcher:

```javascript
  // if we import the routeConfig at the top of redux-store, it causes a circular depenedency
  // with the Components imported from the routes file and tests won't run
  // hack here is to only add the creatMatchEnhancer to the store if not running tests
  const isRunningTests = process.env.NODE_ENV === 'test';
  if (!isRunningTests) {
    // tslint:disable-next-line
    const { routeConfig } = require('../routing/routes');
    composeArgs.push(createMatchEnhancer(
      new Matcher(routeConfig),
    ));
  }
```