### PR TITLE
[typescript] add withRouter test, update ts to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,6 @@
     "react-stand-in": "^4.0.0-beta.14",
     "react-test-renderer": "^16.3.2",
     "rimraf": "^2.6.2",
-    "typescript": "^2.8.1"
+    "typescript": "^3.0.3"
   }
 }

--- a/test/typescript/MainPage.tsx
+++ b/test/typescript/MainPage.tsx
@@ -1,4 +1,9 @@
 import * as React from 'react';
+import WithRouterComponent from './WithRouterComponent';
 
-const Component = () => <div />;
+const Component = () => (
+  <div>
+    <WithRouterComponent />
+  </div>
+);
 export default Component;

--- a/test/typescript/WithRouterComponent.tsx
+++ b/test/typescript/WithRouterComponent.tsx
@@ -1,0 +1,22 @@
+import { WithRouter, withRouter } from 'found';
+import * as React from 'react';
+
+export interface MyProps {
+  foo?: boolean;
+}
+
+export default withRouter(
+  class MyRoutedComponent extends React.Component<MyProps & WithRouter> {
+    public render() {
+      const {
+        match: { location },
+        router,
+      } = this.props;
+      return (
+        <div>
+          {location.pathname}, {router}
+        </div>
+      );
+    }
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5265,9 +5265,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.8.1:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Inconsequential changes - I was having some issues in my local codebase so I figured I would add a test proving that `withRouter` was typed correctly.