### PR TITLE
feat: Do not match stem routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,29 +587,10 @@ The options object also accepts a number of optional properties:
 
 - `historyMiddlewares`: an array of Farce history middlewares; by default, an array containing only `queryMiddleware`
 - `historyOptions`: additional configuration options for the Farce history store enhancer
-- `matcherOptions`: configuration options for the route matcher
-  - `matchStemRoutes`: whether to match routes that are not leaf routes (see below); defaults to `true` if not explicitly specified, though future releases may deprecate and warn on this behavior in advance of changing the default
 - `renderPending`: a custom render function called when some routes are not yet ready to render, due to those routes have unresolved asynchronous dependencies and no route-level `render` method for handling the loading state
 - `renderReady`: a custom render function called when all routes are ready to render
 - `renderError`: a custom render function called if an `HttpError` is thrown while resolving route elements
 - `render`: a custom render function called in all cases, superseding `renderPending`, `renderReady`, and `renderError`; by default, this is `createRender({ renderPending, renderReady, renderError })`
-
-`matchStemRoutes` in `matcherOptions` controls whether routes that are not leaf routes will match. Given the following route configuration:
-
-```js
-<Route path="foo">
-  <Route path="bar" />
-</Route>
-```
-
-The path `/foo` will match if `matchStemRoutes` is enabled. To match on `/foo` when `matchStemRoutes` is disabled, specify this equivalent route configuration:
-
-```js
-<Route path="foo">
-  <Route />
-  <Route path="bar" />
-</Route>
-```
 
 The `renderPending`, `renderReady`, `renderError`, and `render` functions receive the routing state object as an argument, with the following additional properties:
 
@@ -688,7 +669,7 @@ const store = createStore(
       protocol: new BrowserProtocol(),
       middlewares: [queryMiddleware],
     }),
-    createMatchEnhancer(new Matcher(routeConfig, { matchStemRoutes: false })),
+    createMatchEnhancer(new Matcher(routeConfig)),
   ),
 );
 

--- a/src/Matcher.js
+++ b/src/Matcher.js
@@ -3,10 +3,8 @@ import pathToRegexp from 'path-to-regexp';
 import warning from 'warning';
 
 export default class Matcher {
-  constructor(routeConfig, { matchStemRoutes = true } = {}) {
+  constructor(routeConfig) {
     this.routeConfig = routeConfig;
-
-    this.matchStemRoutes = matchStemRoutes;
 
     // Overly-aggressive deduplication of packages can lead to the wrong
     // version of path-to-regexp getting bundled. This is a common enough
@@ -88,10 +86,8 @@ export default class Matcher {
         }
       }
 
-      if (!remaining) {
-        if (this.matchStemRoutes || !children) {
-          return [{ index, params }];
-        }
+      if (!remaining && !children) {
+        return [{ index, params }];
       }
     }
 

--- a/src/createFarceRouter.js
+++ b/src/createFarceRouter.js
@@ -11,7 +11,6 @@ export default function createFarceRouter({
   historyMiddlewares,
   historyOptions,
   routeConfig,
-  matcherOptions,
   ...options
 }) {
   const ConnectedRouter = createConnectedRouter(options);
@@ -27,7 +26,6 @@ export default function createFarceRouter({
           historyMiddlewares,
           historyOptions,
           routeConfig,
-          matcherOptions,
         });
     }
 

--- a/src/utils/createFarceStore.js
+++ b/src/utils/createFarceStore.js
@@ -12,7 +12,6 @@ export default function createFarceStore({
   historyMiddlewares,
   historyOptions,
   routeConfig,
-  matcherOptions,
 }) {
   const store = createStore(
     combineReducers({
@@ -24,7 +23,7 @@ export default function createFarceStore({
         protocol: historyProtocol,
         middlewares: historyMiddlewares || [queryMiddleware],
       }),
-      createMatchEnhancer(new Matcher(routeConfig, matcherOptions)),
+      createMatchEnhancer(new Matcher(routeConfig)),
     ),
   );
 

--- a/test/Matcher.test.js
+++ b/test/Matcher.test.js
@@ -2,35 +2,30 @@ import Matcher from '../src/Matcher';
 
 describe('Matcher', () => {
   describe('route hierarchies', () => {
-    function createMatcher(options) {
-      return new Matcher(
-        [
+    const matcher = new Matcher([
+      {
+        path: 'foo',
+        children: [
           {
-            path: 'foo',
-            children: [
-              {
-                children: [{}],
-              },
-              {
-                path: 'bar',
-              },
-            ],
+            children: [{}],
           },
           {
             path: 'bar',
-            children: [
-              {
-                path: 'baz',
-              },
-            ],
-          },
-          {
-            path: 'foo/baz',
           },
         ],
-        options,
-      );
-    }
+      },
+      {
+        path: 'bar',
+        children: [
+          {
+            path: 'baz',
+          },
+        ],
+      },
+      {
+        path: 'foo/baz',
+      },
+    ]);
 
     [
       ['pathless children', '/foo', [0, 0, 0]],
@@ -40,17 +35,7 @@ describe('Matcher', () => {
       describe(scenario, () => {
         it('should be supported', () => {
           expect(
-            createMatcher().match({
-              pathname,
-            }),
-          ).toMatchObject({
-            routeIndices: expectedRouteIndices,
-          });
-        });
-
-        it('should be supported with matchStemRoutes disabled', () => {
-          expect(
-            createMatcher({ matchStemRoutes: false }).match({
+            matcher.match({
               pathname,
             }),
           ).toMatchObject({
@@ -60,24 +45,12 @@ describe('Matcher', () => {
       });
     });
 
-    describe('stem routes', () => {
-      it('should be supported by default', () => {
-        expect(
-          createMatcher().match({
-            pathname: '/bar',
-          }),
-        ).toMatchObject({
-          routeIndices: [1],
-        });
-      });
-
-      it('should not be supported with matchStemRoutes disabled', () => {
-        expect(
-          createMatcher({ matchStemRoutes: false }).match({
-            pathname: '/bar',
-          }),
-        ).toBeNull();
-      });
+    it('should not match stem routes', () => {
+      expect(
+        matcher.match({
+          pathname: '/bar',
+        }),
+      ).toBeNull();
     });
   });
 
@@ -196,6 +169,7 @@ describe('Matcher', () => {
         {
           path: ':foo',
           children: [
+            {},
             {
               path: '*',
             },
@@ -208,8 +182,8 @@ describe('Matcher', () => {
           pathname: '/a',
         }),
       ).toEqual({
-        routeIndices: [0],
-        routeParams: [{ foo: 'a' }],
+        routeIndices: [0, 0],
+        routeParams: [{ foo: 'a' }, {}],
         params: {
           foo: 'a',
         },
@@ -220,7 +194,7 @@ describe('Matcher', () => {
           pathname: '/a/b/c',
         }),
       ).toEqual({
-        routeIndices: [0, 0],
+        routeIndices: [0, 1],
         routeParams: [{ foo: 'a' }, { 0: 'b/c' }],
         params: {
           foo: 'a',
@@ -274,6 +248,7 @@ describe('Matcher', () => {
       {
         path: 'foo',
         children: [
+          {},
           {
             path: 'bar',
           },
@@ -282,10 +257,10 @@ describe('Matcher', () => {
     ]);
 
     [
-      ['parent without trailing slash', '/foo', [0]],
-      ['parent with trailing slash', '/foo/', [0]],
-      ['child without trailing slash', '/foo/bar', [0, 0]],
-      ['child with trailing slash', '/foo/bar/', [0, 0]],
+      ['parent without trailing slash', '/foo', [0, 0]],
+      ['parent with trailing slash', '/foo/', [0, 0]],
+      ['child without trailing slash', '/foo/bar', [0, 1]],
+      ['child with trailing slash', '/foo/bar/', [0, 1]],
     ].forEach(([scenario, pathname, expectedRouteIndices]) => {
       it(`should match ${scenario}`, () => {
         expect(


### PR DESCRIPTION
BREAKING CHANGE: Removed matchStemRoutes and made the previous false
behavior the default

Note base branch.