### PR TITLE
fix: handle links with a _self target

### DIFF
--- a/src/BaseLink.js
+++ b/src/BaseLink.js
@@ -33,7 +33,7 @@ class BaseLink extends React.Component {
 
     // Don't do anything if the user's onClick handler prevented default.
     // Otherwise, let the browser handle the link with the computed href if the
-    // event wasn't an unmodified left click, or if the link has a target.
+    // event wasn't an unmodified left click, or if the link has a target different than self.
     if (
       event.defaultPrevented ||
       event.metaKey ||
@@ -41,7 +41,7 @@ class BaseLink extends React.Component {
       event.ctrlKey ||
       event.shiftKey ||
       event.button !== 0 ||
-      target
+      (target && target !== '_self')
     ) {
       return;
     }

--- a/src/BaseLink.js
+++ b/src/BaseLink.js
@@ -33,7 +33,8 @@ class BaseLink extends React.Component {
 
     // Don't do anything if the user's onClick handler prevented default.
     // Otherwise, let the browser handle the link with the computed href if the
-    // event wasn't an unmodified left click, or if the link has a target different than self.
+    // event wasn't an unmodified left click, or if the link has a target other
+    // than _self.
     if (
       event.defaultPrevented ||
       event.metaKey ||

--- a/test/BaseLink.test.js
+++ b/test/BaseLink.test.js
@@ -87,7 +87,7 @@ describe('<BaseLink>', () => {
       expect(router.push).not.toBeCalled();
     });
 
-    it('should not navigate if target is defined and different than _self', () => {
+    it('should not navigate if target is defined and not _self', () => {
       const link = mount(
         <BaseLink to="/" match={{}} router={router} target="_blank" />,
       );
@@ -95,15 +95,15 @@ describe('<BaseLink>', () => {
       link.find('a').simulate('click', { button: 0 });
       expect(router.push).not.toBeCalled();
     });
-  });
 
-  it('should navigate if target is _self', () => {
-    const link = mount(
-      <BaseLink to="/" match={{}} router={router} target="_self" />,
-    );
+    it('should navigate if target is _self', () => {
+      const link = mount(
+        <BaseLink to="/" match={{}} router={router} target="_self" />,
+      );
 
-    link.find('a').simulate('click', { button: 0 });
-    expect(router.push).toBeCalled();
+      link.find('a').simulate('click', { button: 0 });
+      expect(router.push).toBeCalled();
+    });
   });
 
   describe('active state', () => {

--- a/test/BaseLink.test.js
+++ b/test/BaseLink.test.js
@@ -87,7 +87,7 @@ describe('<BaseLink>', () => {
       expect(router.push).not.toBeCalled();
     });
 
-    it('should not navigate if target is defined', () => {
+    it('should not navigate if target is defined and different than _self', () => {
       const link = mount(
         <BaseLink to="/" match={{}} router={router} target="_blank" />,
       );
@@ -95,6 +95,15 @@ describe('<BaseLink>', () => {
       link.find('a').simulate('click', { button: 0 });
       expect(router.push).not.toBeCalled();
     });
+  });
+
+  it('should navigate if target is _self', () => {
+    const link = mount(
+      <BaseLink to="/" match={{}} router={router} target="_self" />,
+    );
+
+    link.find('a').simulate('click', { button: 0 });
+    expect(router.push).toBeCalled();
   });
 
   describe('active state', () => {


### PR DESCRIPTION
Links having a `_self` target could be handled by Found.
This fix is based on a [PR](https://github.com/ReactTraining/react-router/pull/6138/files#diff-8c17f8f99262d24cba447ddc8f465455R41) in react-router.