### PR TITLE
fix: Make react-redux a direct dependency again

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ export default AppPage;
 ### Installation
 
 ```
-$ npm i -S react react-redux
+$ npm i -S react
 $ npm i -S found
 ```
 
@@ -699,6 +699,8 @@ ReactDOM.render(
   document.getElementById('root'),
 );
 ```
+
+> **Note:** Found uses `redux` and `react-redux` as direct dependencies for the convenience of users not directly using Redux. If you are directly using Redux, either ensure that you have the same versions of `redux` and `react-redux` installed as used in Found, or use package manager or bundler resolutions to force Found to use the same versions of those packages that you are using directly. Found is compatible with any current release of `redux` or `react-redux`.
 
 When creating a store for use with the created `<ConnectedRouter>`, you should install the `foundReducer` reducer under the `found` key. You should also use a store enhancer created with `createHistoryEnhancer` from Farce and a store enhancer created with `createMatchEnhancer`, which must go after the history store enhancer. Dispatch `FarceActions.init()` after setting up your store to initialize the event listeners and the initial location for the history store enhancer.
 

--- a/package.json
+++ b/package.json
@@ -86,13 +86,13 @@
     "lodash": "^4.17.11",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.7.2",
+    "react-redux": "^7.0.1",
     "react-static-container": "^1.0.2",
     "redux": "^4.0.1",
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=16.4.0",
-    "react-redux": ">=5.0.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@4c/babel-preset": "^5.1.0",
@@ -127,7 +127,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-proxy": "^3.0.0-alpha.1",
-    "react-redux": "^7.0.1",
     "react-stand-in": "^4.0.0-beta.14",
     "react-test-renderer": "^16.8.6",
     "rimraf": "^2.6.3"


### PR DESCRIPTION
BREAKING CHANGE: Bump minimum required version of react