### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ Found exposes lower-level functionality for doing server-side rendering for use 
 
 ```js
 import { getStoreRenderArgs } from 'found';
-import { RouterProvider } from 'found/lib/server';
+import RouterProvider from 'found/lib/server/RouterProvider';
 
 /* ... */
 


### PR DESCRIPTION
Fix to import `RouterProvider` from the correct place.
It doesn't seem to be exported from server/index anymore..