### PR TITLE
fix: Fix build script for recursive copy 'types' dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "babel src -d lib --delete-dir-on-start && cpy types/*.d.ts lib",
+    "build": "babel src -d lib --delete-dir-on-start && cpy **/*.d.ts ../lib --cwd=types --parents",
     "format": "eslint --fix . && npm run prettier -- --write",
     "lint": "eslint . && npm run prettier -- -l",
     "prepublish": "npm run build",


### PR DESCRIPTION
types/server/*.d.ts files are missing in npm.

![Annotation 2019-07-12 153452](https://user-images.githubusercontent.com/14291129/61107326-a32cb800-a4ba-11e9-8f62-f5bc44236cde.png)
