### PR TITLE
Fixes match being `undefined`

### DIFF
--- a/src/createMatchEnhancer.js
+++ b/src/createMatchEnhancer.js
@@ -10,12 +10,15 @@ function createMatchMiddleware(matcher) {
       if (type !== FarceActionTypes.UPDATE_LOCATION) {
         return next(action);
       }
-
+      const match = matcher.match(payload);
+      if (!match) {
+        throw new Error('Route not found: ' + payload.pathname);
+      }
       return next({
         type: ActionTypes.UPDATE_MATCH,
         payload: {
           location: payload,
-          ...matcher.match(payload),
+          ...match,
         },
       });
     };


### PR DESCRIPTION
Related issue: https://github.com/4Catalyzer/found/issues/632
I didn't check whether it's really `undefined` there but seems like it could be the case because `...undefined` is the same as "nothing".
@taion What do you think?