### PR TITLE
Fix missing react-dom peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "publishConfig": {
     "directory": "lib"


### PR DESCRIPTION
`Module not found: Error: react-redux tried to access react-dom (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.`