### PR TITLE
Fixes 'ElementsRenderer' only refers to a type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -506,6 +506,7 @@ export interface ElementsRendererProps {
 }
 
 export type ElementsRenderer = React.ComponentType<ElementsRendererProps>;
+export const ElementsRenderer: ElementsRenderer;
 
 export interface GetStoreRenderArgsOptions {
   store: Store;


### PR DESCRIPTION
## What does it do?
Fixes Typescript error: 'ElementsRenderer' only refers to a type, but is being used as a value here.