### PR TITLE
feat: remove extra deps and vendor in old ass path2regexp

### DIFF
--- a/examples/global-pending/src/index.js
+++ b/examples/global-pending/src/index.js
@@ -1,10 +1,10 @@
 import ElementsRenderer from 'found/ElementsRenderer';
 import Link from 'found/Link';
+import StaticContainer from 'found/StaticContainer';
 import createBrowserRouter from 'found/createBrowserRouter';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import StaticContainer from 'react-static-container';
 
 function LinkItem(props) {
   return (

--- a/package.json
+++ b/package.json
@@ -65,16 +65,13 @@
     "@babel/runtime": "^7.12.5",
     "@restart/context": "^2.1.4",
     "@types/react": ">=16.9.31",
+    "dequal": "^2.0.2",
     "farce": "^0.4.5",
-    "invariant": "^2.2.4",
     "is-promise": "^4.0.0",
-    "lodash": "^4.17.20",
-    "path-to-regexp": "^1.7.0",
     "prop-types": "^15.7.2",
     "react-redux": "^7.2.2",
-    "react-static-container": "^1.0.2",
     "redux": "^4.0.4",
-    "warning": "^4.0.3"
+    "tiny-warning": "^1.0.3"
   },
   "devDependencies": {
     "@4c/babel-preset": "^8.0.3",

--- a/src/BaseLink.js
+++ b/src/BaseLink.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import warning from 'warning';
+import warning from 'tiny-warning';
 
 import { routerShape } from './PropTypes';
 

--- a/src/Matcher.js
+++ b/src/Matcher.js
@@ -1,18 +1,11 @@
-import isEqual from 'lodash/isEqual';
-import pathToRegexp from 'path-to-regexp';
-import warning from 'warning';
+import { dequal } from 'dequal';
+import warning from 'tiny-warning';
+
+import pathToRegexp from './pathToRegexp';
 
 export default class Matcher {
   constructor(routeConfig) {
     this.routeConfig = routeConfig;
-
-    // Overly-aggressive deduplication of packages can lead to the wrong
-    // version of path-to-regexp getting bundled. This is a common enough
-    // failure mode that it's worthwhile to add a dev-only warning here.
-    warning(
-      typeof pathToRegexp.compile === 'function',
-      'Incorrect version of path-to-regexp imported. If this is running from a client bundle, check your bundler settings.',
-    );
   }
 
   match({ pathname }) {
@@ -254,7 +247,7 @@ export default class Matcher {
 
     return Object.entries(query).every(([key, value]) =>
       Object.prototype.hasOwnProperty.call(matchQuery, key)
-        ? isEqual(matchQuery[key], value)
+        ? dequal(matchQuery[key], value)
         : value === undefined,
     );
   }

--- a/src/ResolverUtils.js
+++ b/src/ResolverUtils.js
@@ -1,5 +1,5 @@
 import isPromise from 'is-promise';
-import warning from 'warning';
+import warning from 'tiny-warning';
 
 const UNRESOLVED = {};
 

--- a/src/StaticContainer.js
+++ b/src/StaticContainer.js
@@ -1,0 +1,16 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+class StaticContainer extends React.Component {
+  shouldComponentUpdate({ shouldUpdate }) {
+    return !!shouldUpdate;
+  }
+
+  render() {
+    const child = this.props.children;
+    if (child === null || child === false) return null;
+    return React.Children.only(child);
+  }
+}
+
+export default StaticContainer;

--- a/src/createBaseRouter.js
+++ b/src/createBaseRouter.js
@@ -1,12 +1,12 @@
 import mapContextToProps from '@restart/context/mapContextToProps';
-import isEqual from 'lodash/isEqual';
+import { dequal } from 'dequal';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { ReactReduxContext } from 'react-redux';
-import StaticContainer from 'react-static-container';
-import warning from 'warning';
+import warning from 'tiny-warning';
 
 import RouterContext from './RouterContext';
+import StaticContainer from './StaticContainer';
 import createRender from './createRender';
 import createStoreRouterObject from './createStoreRouterObject';
 import resolveRenderArgs from './resolveRenderArgs';
@@ -100,7 +100,7 @@ export default function createBaseRouter({
       if (
         match !== state.match ||
         resolver !== state.resolver ||
-        !isEqual(matchContext, state.matchContext)
+        !dequal(matchContext, state.matchContext)
       ) {
         return {
           match,

--- a/src/createElements.js
+++ b/src/createElements.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import warning from 'warning';
+import warning from 'tiny-warning';
 
 import { isResolved } from './ResolverUtils';
 

--- a/src/createRender.js
+++ b/src/createRender.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import StaticContainer from 'react-static-container';
 
 import ElementsRenderer from './ElementsRenderer';
+import StaticContainer from './StaticContainer';
 
 // These are intentionally not renderLoading, renderFetched, and renderFailure
 // from Relay, because these don't quite correspond to those conditions.

--- a/src/makeRouteConfig.js
+++ b/src/makeRouteConfig.js
@@ -1,4 +1,3 @@
-import invariant from 'invariant';
 import React from 'react';
 
 function buildRouteConfig(node, routeConfig) {
@@ -9,11 +8,9 @@ function buildRouteConfig(node, routeConfig) {
       return;
     }
 
-    invariant(
-      React.isValidElement(child),
-      '`%s` is not a valid React element',
-      child,
-    );
+    if (!React.isValidElement(child)) {
+      throw new TypeError(`\`${child}\` is not a valid React element`);
+    }
 
     let Type = child.type;
     const { children, ...props } = child.props;

--- a/src/pathToRegexp.js
+++ b/src/pathToRegexp.js
@@ -1,0 +1,452 @@
+/* eslint-disable */
+// Vendored ancient version of path-to-regexp
+module.exports = pathToRegexp;
+module.exports.parse = parse;
+module.exports.compile = compile;
+module.exports.tokensToFunction = tokensToFunction;
+module.exports.tokensToRegExp = tokensToRegExp;
+
+/**
+ * The main path matching regexp utility.
+ *
+ * @type {RegExp}
+ */
+const PATH_REGEXP = new RegExp(
+  [
+    // Match escaped characters that would otherwise appear in future matches.
+    // This allows the user to escape special characters that won't transform.
+    '(\\\\.)',
+    // Match Express-style parameters and un-named parameters with a prefix
+    // and optional suffixes. Matches appear as:
+    //
+    // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
+    // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
+    // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
+    '([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))',
+  ].join('|'),
+  'g',
+);
+
+/**
+ * Parse a string for the raw tokens.
+ *
+ * @param  {string}  str
+ * @param  {Object=} options
+ * @return {!Array}
+ */
+function parse(str, options) {
+  const tokens = [];
+  let key = 0;
+  let index = 0;
+  let path = '';
+  const defaultDelimiter = (options && options.delimiter) || '/';
+  let res;
+
+  while ((res = PATH_REGEXP.exec(str)) != null) {
+    const m = res[0];
+    const escaped = res[1];
+    const offset = res.index;
+    path += str.slice(index, offset);
+    index = offset + m.length;
+
+    // Ignore already escaped sequences.
+    if (escaped) {
+      path += escaped[1];
+      continue;
+    }
+
+    const next = str[index];
+    const prefix = res[2];
+    const name = res[3];
+    const capture = res[4];
+    const group = res[5];
+    const modifier = res[6];
+    const asterisk = res[7];
+
+    // Push the current path onto the tokens.
+    if (path) {
+      tokens.push(path);
+      path = '';
+    }
+
+    const partial = prefix != null && next != null && next !== prefix;
+    const repeat = modifier === '+' || modifier === '*';
+    const optional = modifier === '?' || modifier === '*';
+    const delimiter = res[2] || defaultDelimiter;
+    const pattern = capture || group;
+
+    tokens.push({
+      name: name || key++,
+      prefix: prefix || '',
+      delimiter,
+      optional,
+      repeat,
+      partial,
+      asterisk: !!asterisk,
+      pattern: pattern
+        ? escapeGroup(pattern)
+        : asterisk
+        ? '.*'
+        : `[^${escapeString(delimiter)}]+?`,
+    });
+  }
+
+  // Match any characters still remaining.
+  if (index < str.length) {
+    path += str.substr(index);
+  }
+
+  // If the path exists, push it onto the end.
+  if (path) {
+    tokens.push(path);
+  }
+
+  return tokens;
+}
+
+/**
+ * Compile a string to a template function for the path.
+ *
+ * @param  {string}             str
+ * @param  {Object=}            options
+ * @return {!function(Object=, Object=)}
+ */
+function compile(str, options) {
+  return tokensToFunction(parse(str, options), options);
+}
+
+/**
+ * Prettier encoding of URI path segments.
+ *
+ * @param  {string}
+ * @return {string}
+ */
+function encodeURIComponentPretty(str) {
+  return encodeURI(str).replace(/[\/?#]/g, function (c) {
+    return `%${c.charCodeAt(0).toString(16).toUpperCase()}`;
+  });
+}
+
+/**
+ * Encode the asterisk parameter. Similar to `pretty`, but allows slashes.
+ *
+ * @param  {string}
+ * @return {string}
+ */
+function encodeAsterisk(str) {
+  return encodeURI(str).replace(/[?#]/g, function (c) {
+    return `%${c.charCodeAt(0).toString(16).toUpperCase()}`;
+  });
+}
+
+/**
+ * Expose a method for transforming tokens into the path function.
+ */
+function tokensToFunction(tokens, options) {
+  // Compile all the tokens into regexps.
+  const matches = new Array(tokens.length);
+
+  // Compile all the patterns before compilation.
+  for (let i = 0; i < tokens.length; i++) {
+    if (typeof tokens[i] === 'object') {
+      matches[i] = new RegExp(`^(?:${tokens[i].pattern})$`, flags(options));
+    }
+  }
+
+  return function (obj, opts) {
+    let path = '';
+    const data = obj || {};
+    const options = opts || {};
+    const encode = options.pretty
+      ? encodeURIComponentPretty
+      : encodeURIComponent;
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+
+      if (typeof token === 'string') {
+        path += token;
+
+        continue;
+      }
+
+      const value = data[token.name];
+      var segment;
+
+      if (value == null) {
+        if (token.optional) {
+          // Prepend partial segment prefixes.
+          if (token.partial) {
+            path += token.prefix;
+          }
+
+          continue;
+        } else {
+          throw new TypeError(`Expected "${token.name}" to be defined`);
+        }
+      }
+
+      if (Array.isArray(value)) {
+        if (!token.repeat) {
+          throw new TypeError(
+            `Expected "${
+              token.name
+            }" to not repeat, but received \`${JSON.stringify(value)}\``,
+          );
+        }
+
+        if (value.length === 0) {
+          if (token.optional) {
+            continue;
+          } else {
+            throw new TypeError(`Expected "${token.name}" to not be empty`);
+          }
+        }
+
+        for (let j = 0; j < value.length; j++) {
+          segment = encode(value[j]);
+
+          if (!matches[i].test(segment)) {
+            throw new TypeError(
+              `Expected all "${token.name}" to match "${
+                token.pattern
+              }", but received \`${JSON.stringify(segment)}\``,
+            );
+          }
+
+          path += (j === 0 ? token.prefix : token.delimiter) + segment;
+        }
+
+        continue;
+      }
+
+      segment = token.asterisk ? encodeAsterisk(value) : encode(value);
+
+      if (!matches[i].test(segment)) {
+        throw new TypeError(
+          `Expected "${token.name}" to match "${token.pattern}", but received "${segment}"`,
+        );
+      }
+
+      path += token.prefix + segment;
+    }
+
+    return path;
+  };
+}
+
+/**
+ * Escape a regular expression string.
+ *
+ * @param  {string} str
+ * @return {string}
+ */
+function escapeString(str) {
+  return str.replace(/([.+*?=^!:${}()[\]|\/\\])/g, '\\$1');
+}
+
+/**
+ * Escape the capturing group by escaping special characters and meaning.
+ *
+ * @param  {string} group
+ * @return {string}
+ */
+function escapeGroup(group) {
+  return group.replace(/([=!:$\/()])/g, '\\$1');
+}
+
+/**
+ * Attach the keys as a property of the regexp.
+ *
+ * @param  {!RegExp} re
+ * @param  {Array}   keys
+ * @return {!RegExp}
+ */
+function attachKeys(re, keys) {
+  re.keys = keys;
+  return re;
+}
+
+/**
+ * Get the flags for a regexp from the options.
+ *
+ * @param  {Object} options
+ * @return {string}
+ */
+function flags(options) {
+  return options && options.sensitive ? '' : 'i';
+}
+
+/**
+ * Pull out keys from a regexp.
+ *
+ * @param  {!RegExp} path
+ * @param  {!Array}  keys
+ * @return {!RegExp}
+ */
+function regexpToRegexp(path, keys) {
+  // Use a negative lookahead to match only capturing groups.
+  const groups = path.source.match(/\((?!\?)/g);
+
+  if (groups) {
+    for (let i = 0; i < groups.length; i++) {
+      keys.push({
+        name: i,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        partial: false,
+        asterisk: false,
+        pattern: null,
+      });
+    }
+  }
+
+  return attachKeys(path, keys);
+}
+
+/**
+ * Transform an array into a regexp.
+ *
+ * @param  {!Array}  path
+ * @param  {Array}   keys
+ * @param  {!Object} options
+ * @return {!RegExp}
+ */
+function arrayToRegexp(path, keys, options) {
+  const parts = [];
+
+  for (let i = 0; i < path.length; i++) {
+    parts.push(pathToRegexp(path[i], keys, options).source);
+  }
+
+  const regexp = new RegExp(`(?:${parts.join('|')})`, flags(options));
+
+  return attachKeys(regexp, keys);
+}
+
+/**
+ * Create a path regexp from string input.
+ *
+ * @param  {string}  path
+ * @param  {!Array}  keys
+ * @param  {!Object} options
+ * @return {!RegExp}
+ */
+function stringToRegexp(path, keys, options) {
+  return tokensToRegExp(parse(path, options), keys, options);
+}
+
+/**
+ * Expose a function for taking tokens and returning a RegExp.
+ *
+ * @param  {!Array}          tokens
+ * @param  {(Array|Object)=} keys
+ * @param  {Object=}         options
+ * @return {!RegExp}
+ */
+function tokensToRegExp(tokens, keys, options) {
+  if (!Array.isArray(keys)) {
+    options = /** @type {!Object} */ (keys || options);
+    keys = [];
+  }
+
+  options = options || {};
+
+  const { strict } = options;
+  const end = options.end !== false;
+  let route = '';
+
+  // Iterate over the tokens and create our regexp string.
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (typeof token === 'string') {
+      route += escapeString(token);
+    } else {
+      const prefix = escapeString(token.prefix);
+      let capture = `(?:${token.pattern})`;
+
+      keys.push(token);
+
+      if (token.repeat) {
+        capture += `(?:${prefix}${capture})*`;
+      }
+
+      if (token.optional) {
+        if (!token.partial) {
+          capture = `(?:${prefix}(${capture}))?`;
+        } else {
+          capture = `${prefix}(${capture})?`;
+        }
+      } else {
+        capture = `${prefix}(${capture})`;
+      }
+
+      route += capture;
+    }
+  }
+
+  const delimiter = escapeString(options.delimiter || '/');
+  const endsWithDelimiter = route.slice(-delimiter.length) === delimiter;
+
+  // In non-strict mode we allow a slash at the end of match. If the path to
+  // match already ends with a slash, we remove it for consistency. The slash
+  // is valid at the end of a path match, not in the middle. This is important
+  // in non-ending mode, where "/test/" shouldn't match "/test//route".
+  if (!strict) {
+    route = `${
+      endsWithDelimiter ? route.slice(0, -delimiter.length) : route
+    }(?:${delimiter}(?=$))?`;
+  }
+
+  if (end) {
+    route += '$';
+  } else {
+    // In non-ending mode, we need the capturing groups to match as much as
+    // possible by using a positive lookahead to the end or next path segment.
+    route += strict && endsWithDelimiter ? '' : `(?=${delimiter}|$)`;
+  }
+
+  return attachKeys(new RegExp(`^${route}`, flags(options)), keys);
+}
+
+/**
+ * Normalize the given path string, returning a regular expression.
+ *
+ * An empty array can be passed in for the keys, which will hold the
+ * placeholder key descriptions. For example, using `/user/:id`, `keys` will
+ * contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
+ *
+ * @param  {(string|RegExp|Array)} path
+ * @param  {(Array|Object)=}       keys
+ * @param  {Object=}               options
+ * @return {!RegExp}
+ */
+function pathToRegexp(path, keys, options) {
+  if (!Array.isArray(keys)) {
+    options = /** @type {!Object} */ (keys || options);
+    keys = [];
+  }
+
+  options = options || {};
+
+  if (path instanceof RegExp) {
+    return regexpToRegexp(path, /** @type {!Array} */ (keys));
+  }
+
+  if (Array.isArray(path)) {
+    return arrayToRegexp(
+      /** @type {!Array} */ (path),
+      /** @type {!Array} */ (keys),
+      options,
+    );
+  }
+
+  return stringToRegexp(
+    /** @type {string} */ (path),
+    /** @type {!Array} */ (keys),
+    options,
+  );
+}

--- a/test/Link-warnings.test.js
+++ b/test/Link-warnings.test.js
@@ -1,7 +1,7 @@
-jest.mock('warning');
+jest.mock('tiny-warning');
 
 import React from 'react';
-import warning from 'warning';
+import warning from 'tiny-warning';
 
 import Link from '../src/Link';
 import { mountWithRouter } from './helpers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,6 +3856,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -6463,11 +6468,6 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -8543,13 +8543,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -8962,11 +8955,6 @@ react-stand-in@^4.0.0-beta.21:
   integrity sha1-+2lORlyyD6t/NtMoT4K2i716ZX4=
   dependencies:
     shallowequal "^1.0.2"
-
-react-static-container@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-static-container/-/react-static-container-1.0.2.tgz#30a4f7548860be1d55d5eb4c20645b835c2bdf34"
-  integrity sha512-rxlZtZk5t6Y3gqqpaZ1lxY3RqlQcBU5uGsSoZj/hbF3ZweDqPbFHDkczT4emAxeaw37OD96RAAoayFGFQZCdWg==
 
 react-test-renderer@^16.0.0-0:
   version "16.14.0"
@@ -10505,6 +10493,11 @@ tiny-glob@^0.2.6:
   dependencies:
     globalyzer "^0.1.0"
     globrex "^0.1.1"
+
+tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 title-case@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
i hate being prompted to upgrade path to rexexp, at this point i don't know why we aren't upgrading it, but no one else is using it so lets just vendor it.