### PR TITLE
fix(docs): minor link fixes

### DIFF
--- a/www/docs/intro.mdx
+++ b/www/docs/intro.mdx
@@ -20,7 +20,7 @@ hide_title: true
 
 Found is a router for [React](https://reactjs.org/) applications with a focus on power and extensibility. Found uses static route configurations. This enables efficient code splitting and data fetching with nested routes. Found also offers extensive control over indicating those loading states, even for routes with code bundles that have not yet been downloaded.
 
-Found is designed to be extremely customizable. Most pieces of Found such as the path matching algorithm and the route element resolution can be fully replaced. This allows [extensions](#extensions) such as [Found Relay](https://github.com/4Catalyzer/found-relay) to provide first-class support for different use cases.
+Found is designed to be extremely customizable. Most pieces of Found such as the path matching algorithm and the route element resolution can be fully replaced. This allows [extensions](/advanced/further-reading) such as [Found Relay](https://github.com/4Catalyzer/found-relay) to provide first-class support for different use cases.
 
 Found uses [Redux](https://redux.js.org/) for state management and [Farce](https://github.com/4Catalyzer/farce) for controlling browser navigation. It can integrate with your existing store and connected components.
 

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -24,7 +24,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/4Catalyzer/found/edit/master',
+          editUrl: 'https://github.com/4Catalyzer/found/edit/master/www',
           routeBasePath: '/',
         },
         theme: {


### PR DESCRIPTION
Noticed that after docs release a one link was broken and 'edit page' at the bottom of every page redirected to the wrong thing