### PR TITLE
feat: types shuffling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
   rules: {
     'prettier/prettier': 'error',
     'no-use-before-define': 'off',
+    'react/no-unused-prop-types': 'off',
   },
 };

--- a/src/ElementsRenderer.ts
+++ b/src/ElementsRenderer.ts
@@ -1,6 +1,24 @@
 import React from 'react';
 
-import { ElementsRendererProps, ResolvedElement } from './typeUtils';
+import HttpError from './HttpError';
+import { RenderArgsElements } from './resolveRenderArgs';
+import { Match, ResolvedElement } from './typeUtils';
+
+export type RenderPendingArgs = Match;
+
+export interface RenderReadyArgs extends Match {
+  elements: RenderArgsElements;
+}
+
+export interface RenderErrorArgs extends Match {
+  error: HttpError;
+}
+
+export type RenderArgs = RenderPendingArgs | RenderReadyArgs | RenderErrorArgs;
+
+export interface ElementsRendererProps {
+  elements: RenderArgsElements;
+}
 
 function accumulateElement(
   children: ResolvedElement,

--- a/src/ElementsRenderer.ts
+++ b/src/ElementsRenderer.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HttpError from './HttpError';
 import { RenderArgsElements } from './resolveRenderArgs';
-import { Match, ResolvedElement } from './typeUtils';
+import { Match, ResolvedElement } from './utilityTypes';
 
 export type RenderPendingArgs = Match;
 

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -2,8 +2,79 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 import React from 'react';
 import warning from 'tiny-warning';
 
-import { LinkInjectedProps, LinkProps } from './typeUtils';
 import useRouter from './useRouter';
+import { LocationDescriptor } from './utilityTypes';
+
+export type LinkPropsWithActivePropName<
+  TInner extends React.ComponentType<
+    LinkInjectedProps & { [activePropName in TActivePropName]: boolean }
+  >,
+  TActivePropName extends string,
+> = ReplaceLinkProps<
+  TInner,
+  LinkPropsNodeChild & {
+    as: TInner;
+    activePropName: TActivePropName;
+  } & {
+    [activePropName in TActivePropName]?: null;
+  }
+>;
+export interface LinkPropsCommon {
+  to: LocationDescriptor;
+  // match: Match,  provided by withRouter
+  // router: Router, provided by withRouter
+  exact?: boolean;
+  target?: string;
+  onClick?: (event: React.SyntheticEvent<any>) => void;
+}
+
+export interface LinkInjectedProps {
+  href: string;
+  onClick: (event: React.SyntheticEvent<any>) => void;
+}
+
+export interface LinkPropsNodeChild extends LinkPropsCommon {
+  activeClassName?: string;
+  activeStyle?: Record<string, unknown>;
+  children?: React.ReactNode;
+}
+
+type ReplaceLinkProps<TInner extends React.ElementType, TProps> = Omit<
+  React.ComponentProps<TInner>,
+  keyof TProps | keyof LinkInjectedProps
+> &
+  TProps;
+
+export type LinkPropsSimple = ReplaceLinkProps<'a', LinkPropsNodeChild>;
+
+export type LinkPropsWithAs<
+  TInner extends React.ElementType<LinkInjectedProps>,
+> = ReplaceLinkProps<
+  TInner,
+  LinkPropsNodeChild & {
+    as: TInner;
+    activePropName?: null;
+  }
+>;
+export interface LinkPropsWithFunctionChild extends LinkPropsCommon {
+  children: (linkRenderArgs: {
+    href: string;
+    active: boolean;
+    onClick: (event: React.SyntheticEvent<any>) => void;
+  }) => React.ReactNode;
+}
+
+export type LinkProps<
+  TInner extends React.ElementType = never,
+  TInnerWithActivePropName extends React.ComponentType<
+    LinkInjectedProps & { [activePropName in TActivePropName]: boolean }
+  > = never,
+  TActivePropName extends string = never,
+> =
+  | LinkPropsSimple
+  | LinkPropsWithAs<TInner>
+  | LinkPropsWithActivePropName<TInnerWithActivePropName, TActivePropName>
+  | LinkPropsWithFunctionChild;
 
 // TODO: Try to type this & simplify those types in next breaking change.
 function Link({

--- a/src/Matcher.ts
+++ b/src/Matcher.ts
@@ -15,7 +15,7 @@ import type {
   RouteConfig,
   RouteIndices,
   RouteObject,
-} from './typeUtils';
+} from './utilityTypes';
 
 export type RouteConfigGroups = Record<string, RouteConfig>;
 

--- a/src/Matcher.ts
+++ b/src/Matcher.ts
@@ -31,6 +31,12 @@ export interface MatcherOptions {
   warnOnPartiallyMatchedNamedRoutes?: boolean;
 }
 
+/**
+ * An object implementing the matching algorithm.
+ *
+ * User code generally shouldn't need this, but it doesn't hurt to here,
+ * since we use it for routerShape below.
+ */
 export default class Matcher {
   private routeConfig: RouteConfig;
 
@@ -76,6 +82,11 @@ export default class Matcher {
     return `${basePath}${this.getCanonicalPattern(path)}`;
   }
 
+  /**
+   * for match as above, returns whether match corresponds to location or a
+   * subpath of location; if exact is set, returns whether match corresponds
+   * exactly to location
+   */
   isActive(
     { location: matchLocation }: Match,
     location: LocationDescriptorObject,
@@ -90,6 +101,10 @@ export default class Matcher {
     );
   }
 
+  /**
+   * Returns the path string for a pattern of the same format as a route path
+   * and a object of the corresponding path parameters
+   */
   format(pattern: string, params: ParamsDescriptor): string {
     return compile(pattern)(params);
   }

--- a/src/Redirect.tsx
+++ b/src/Redirect.tsx
@@ -2,7 +2,13 @@
 import React from 'react';
 
 import RedirectException from './RedirectException';
-import { LocationDescriptor, Match, RedirectOptions } from './typeUtils';
+import { LocationDescriptor, Match } from './utilityTypes';
+
+export interface RedirectOptions {
+  from?: string;
+  to: string | ((match: Match) => LocationDescriptor);
+  status?: number;
+}
 
 class Redirect implements RedirectOptions {
   path?: string;
@@ -38,8 +44,11 @@ if (__DEV__) {
   (Redirect.prototype as any).isReactComponent = {};
 }
 
+// It's more "natural" to call this "props" when used in the context of a
+//  React component.
+export type RedirectProps = RedirectOptions;
 // This actually doesn't extend a React.Component, but we need consumer to think that it does
-declare class RedirectType extends React.Component<RedirectOptions> {
+declare class RedirectType extends React.Component<RedirectProps> {
   constructor(config: RedirectOptions);
 }
 

--- a/src/ResolverUtils.ts
+++ b/src/ResolverUtils.ts
@@ -2,7 +2,12 @@ import isPromise from 'is-promise';
 import { setImmediate } from 'tiny-set-immediate';
 import warning from 'tiny-warning';
 
-import { Match, RouteIndices, RouteMatch, RouteObjectBase } from './typeUtils';
+import {
+  Match,
+  RouteIndices,
+  RouteMatch,
+  RouteObjectBase,
+} from './utilityTypes';
 
 const UNRESOLVED = {};
 

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -1,7 +1,15 @@
 // eslint-disable-next-line max-classes-per-file
 import React from 'react';
 
-import type { RouteObject, RouteProps } from './utilityTypes';
+import type { RouteObject, RouteObjectBase } from './utilityTypes';
+
+export interface RouteProps extends RouteObjectBase {
+  children?: React.ReactNode | Record<string, React.ReactNode>;
+}
+
+export interface RouteProps extends RouteObjectBase {
+  children?: React.ReactNode | Record<string, React.ReactNode>;
+}
 
 /**
  * Convenience class for creating normal routes with JSX. When not using JSX,

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
 import React from 'react';
 
-import type { RouteObject, RouteProps } from './typeUtils';
+import type { RouteObject, RouteProps } from './utilityTypes';
 
 /**
  * Convenience class for creating normal routes with JSX. When not using JSX,

--- a/src/RouterContext.ts
+++ b/src/RouterContext.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Match, Router } from './typeUtils';
+import { Match, Router } from './utilityTypes';
 
 export interface RouterContextState<TContext = any> {
   match: Match<TContext> | null;

--- a/src/createBaseRouter.tsx
+++ b/src/createBaseRouter.tsx
@@ -4,19 +4,19 @@ import { Store } from 'redux';
 import warning from 'tiny-warning';
 
 import ActionTypes from './ActionTypes';
+import { RenderArgs } from './ElementsRenderer';
 import RouterContext, { RouterContextState } from './RouterContext';
 import StaticContainer from './StaticContainer';
-import createRender from './createRender';
+import createRender, { CreateRenderOptions } from './createRender';
 import createStoreRouterObject from './createStoreRouterObject';
 import resolveRenderArgs from './resolveRenderArgs';
-import {
-  ConnectedRouterProps,
-  CreateRenderOptions,
-  MatchBase,
-  RenderArgs,
-  Resolver,
-  Router,
-} from './typeUtils';
+import { MatchBase, Resolver } from './typeUtils';
+
+export interface ConnectedRouterProps {
+  matchContext?: any;
+  resolver: Resolver;
+  initialRenderArgs?: RenderArgs;
+}
 
 interface CreateProps extends CreateRenderOptions {
   render?: (args: RenderArgs) => React.ReactElement;

--- a/src/createBaseRouter.tsx
+++ b/src/createBaseRouter.tsx
@@ -10,7 +10,7 @@ import StaticContainer from './StaticContainer';
 import createRender, { CreateRenderOptions } from './createRender';
 import createStoreRouterObject from './createStoreRouterObject';
 import resolveRenderArgs from './resolveRenderArgs';
-import { MatchBase, Resolver } from './typeUtils';
+import { MatchBase, Resolver, Router } from './utilityTypes';
 
 export interface ConnectedRouterProps {
   matchContext?: any;

--- a/src/createBrowserRouter.tsx
+++ b/src/createBrowserRouter.tsx
@@ -1,13 +1,24 @@
 import BrowserProtocol from 'farce/BrowserProtocol';
 import React from 'react';
 
-import createFarceRouter from './createFarceRouter';
-import resolver from './resolver';
-import {
-  BrowserRouter,
-  BrowserRouterOptions,
+import { RenderArgs } from './ElementsRenderer';
+import createFarceRouter, {
+  FarceRouterOptions,
   FarceRouterProps,
-} from './typeUtils';
+} from './createFarceRouter';
+import resolver from './resolver';
+import { Resolver } from './typeUtils';
+
+export interface BrowserRouterProps
+  extends Omit<FarceRouterProps, 'resolver'> {
+  resolver?: Resolver;
+}
+
+export type BrowserRouter = React.ComponentType<BrowserRouterProps>;
+export interface BrowserRouterOptions
+  extends Omit<FarceRouterOptions, 'historyProtocol'> {
+  render?: (args: RenderArgs) => React.ReactElement;
+}
 
 export default function createBrowserRouter(
   options: BrowserRouterOptions,

--- a/src/createBrowserRouter.tsx
+++ b/src/createBrowserRouter.tsx
@@ -7,7 +7,7 @@ import createFarceRouter, {
   FarceRouterProps,
 } from './createFarceRouter';
 import resolver from './resolver';
-import { Resolver } from './typeUtils';
+import { Resolver } from './utilityTypes';
 
 export interface BrowserRouterProps
   extends Omit<FarceRouterProps, 'resolver'> {

--- a/src/createConnectedRouter.tsx
+++ b/src/createConnectedRouter.tsx
@@ -2,18 +2,21 @@ import React from 'react';
 import { shallowEqual, useSelector, useStore } from 'react-redux';
 import { Store } from 'redux';
 
-import createBaseRouter from './createBaseRouter';
-import {
-  ConnectedRouterOptions,
-  ConnectedRouterProps,
-  ConnectedRouter as ConnectedRouterType,
-  FoundState,
-} from './typeUtils';
+import { RenderArgs } from './ElementsRenderer';
+import createBaseRouter, { ConnectedRouterProps } from './createBaseRouter';
+import { CreateRenderOptions } from './createRender';
+import { FoundState } from './typeUtils';
+
+export type ConnectedRouter = React.ComponentType<ConnectedRouterProps>;
+export interface ConnectedRouterOptions extends CreateRenderOptions {
+  render?: (args: RenderArgs) => React.ReactElement;
+  getFound?: (store: Store) => FoundState;
+}
 
 export default function createConnectedRouter({
   getFound = ({ found }: any) => found as FoundState,
   ...options
-}: ConnectedRouterOptions): ConnectedRouterType {
+}: ConnectedRouterOptions): ConnectedRouter {
   const Router = createBaseRouter(options);
 
   const getFoundState = (state: Store) => {

--- a/src/createConnectedRouter.tsx
+++ b/src/createConnectedRouter.tsx
@@ -5,7 +5,7 @@ import { Store } from 'redux';
 import { RenderArgs } from './ElementsRenderer';
 import createBaseRouter, { ConnectedRouterProps } from './createBaseRouter';
 import { CreateRenderOptions } from './createRender';
-import { FoundState } from './typeUtils';
+import { FoundState } from './utilityTypes';
 
 export type ConnectedRouter = React.ComponentType<ConnectedRouterProps>;
 export interface ConnectedRouterOptions extends CreateRenderOptions {

--- a/src/createElements.tsx
+++ b/src/createElements.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import warning from 'tiny-warning';
 
 import { isResolved } from './ResolverUtils';
-import { Match, ResolvedElement, RouteMatch } from './typeUtils';
+import { Match, ResolvedElement, RouteMatch } from './utilityTypes';
 
 /**
  * maps an array of `Route`s to React elements. The returned array

--- a/src/createFarceRouter.tsx
+++ b/src/createFarceRouter.tsx
@@ -6,7 +6,7 @@ import { Middleware, Store } from 'redux';
 import createBaseRouter, { ConnectedRouterProps } from './createBaseRouter';
 import { ConnectedRouterOptions } from './createConnectedRouter';
 import createFarceStore from './createFarceStore';
-import { FoundState, RouteConfig } from './typeUtils';
+import { FoundState, RouteConfig } from './utilityTypes';
 
 export interface FarceRouterOptions extends ConnectedRouterOptions {
   store?: Store;

--- a/src/createFarceRouter.tsx
+++ b/src/createFarceRouter.tsx
@@ -1,10 +1,23 @@
 import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
+import { HistoryEnhancerOptions, Protocol } from 'farce';
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { Middleware, Store } from 'redux';
 
-import createBaseRouter from './createBaseRouter';
+import createBaseRouter, { ConnectedRouterProps } from './createBaseRouter';
+import { ConnectedRouterOptions } from './createConnectedRouter';
 import createFarceStore from './createFarceStore';
-import { FarceRouter, FarceRouterOptions, FoundState } from './typeUtils';
+import { FoundState, RouteConfig } from './typeUtils';
 
+export interface FarceRouterOptions extends ConnectedRouterOptions {
+  store?: Store;
+  historyProtocol: Protocol;
+  historyMiddlewares?: Middleware[];
+  historyOptions?: Omit<HistoryEnhancerOptions, 'protocol' | 'middlewares'>;
+  routeConfig: RouteConfig;
+}
+
+export type FarceRouter = React.ComponentType<FarceRouterProps>;
+export type FarceRouterProps = ConnectedRouterProps;
 export default function createFarceRouter({
   store: userStore,
   historyProtocol,

--- a/src/createFarceStore.ts
+++ b/src/createFarceStore.ts
@@ -15,7 +15,7 @@ import {
 import Matcher from './Matcher';
 import createMatchEnhancer from './createMatchEnhancer';
 import foundReducer from './foundReducer';
-import { RouteConfig } from './typeUtils';
+import { RouteConfig } from './utilityTypes';
 
 interface Props {
   matcherOptions?: any;

--- a/src/createInitialBrowserRouter.ts
+++ b/src/createInitialBrowserRouter.ts
@@ -1,8 +1,15 @@
 import BrowserProtocol from 'farce/BrowserProtocol';
 
-import createInitialFarceRouter from './createInitialFarceRouter';
+import { BrowserRouter } from './createBrowserRouter';
+import createInitialFarceRouter, {
+  InitialFarceRouterOptions,
+} from './createInitialFarceRouter';
 import resolver from './resolver';
-import { BrowserRouter, InitialBrowserRouterOptions } from './typeUtils';
+
+export type InitialBrowserRouterOptions = Omit<
+  InitialFarceRouterOptions,
+  'resolver' | 'historyProtocol'
+>;
 
 export default function createInitialBrowserRouter(
   options: InitialBrowserRouterOptions,

--- a/src/createInitialFarceRouter.ts
+++ b/src/createInitialFarceRouter.ts
@@ -4,7 +4,7 @@ import createFarceRouter, {
 } from './createFarceRouter';
 import createFarceStore from './createFarceStore';
 import getStoreRenderArgs from './getStoreRenderArgs';
-import { Resolver } from './typeUtils';
+import { Resolver } from './utilityTypes';
 
 export interface InitialFarceRouterOptions
   extends Omit<FarceRouterOptions, 'store'> {

--- a/src/createInitialFarceRouter.ts
+++ b/src/createInitialFarceRouter.ts
@@ -1,7 +1,16 @@
-import createFarceRouter from './createFarceRouter';
+import createFarceRouter, {
+  FarceRouter,
+  FarceRouterOptions,
+} from './createFarceRouter';
 import createFarceStore from './createFarceStore';
 import getStoreRenderArgs from './getStoreRenderArgs';
-import { FarceRouter, InitialFarceRouterOptions } from './typeUtils';
+import { Resolver } from './typeUtils';
+
+export interface InitialFarceRouterOptions
+  extends Omit<FarceRouterOptions, 'store'> {
+  matchContext?: any;
+  resolver: Resolver;
+}
 
 export default async function createInitialFarceRouter({
   historyProtocol,

--- a/src/createMatchEnhancer.ts
+++ b/src/createMatchEnhancer.ts
@@ -3,7 +3,7 @@ import { Middleware, Store, StoreEnhancer, applyMiddleware } from 'redux';
 
 import ActionTypes from './ActionTypes';
 import Matcher from './Matcher';
-import { FoundState, FoundStoreExtension, RouteConfig } from './typeUtils';
+import { FoundState, FoundStoreExtension, RouteConfig } from './utilityTypes';
 
 function createMatchMiddleware(
   matcher: Matcher,

--- a/src/createRender.tsx
+++ b/src/createRender.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 
-import ElementsRenderer from './ElementsRenderer';
+import ElementsRenderer, {
+  RenderArgs,
+  RenderErrorArgs,
+  RenderPendingArgs,
+  RenderReadyArgs,
+} from './ElementsRenderer';
 import StaticContainer from './StaticContainer';
-import { CreateRenderOptions, RenderArgs } from './typeUtils';
+
+export interface CreateRenderOptions {
+  renderPending?: (args: RenderPendingArgs) => React.ReactElement;
+  renderReady?: (args: RenderReadyArgs) => React.ReactElement;
+  renderError?: (args: RenderErrorArgs) => React.ReactNode;
+}
 
 /**
  * A convenience method for handling the 3 main states a route match might produce.

--- a/src/createStoreRouterObject.ts
+++ b/src/createStoreRouterObject.ts
@@ -1,7 +1,7 @@
 import FarceActions from 'farce/Actions';
 import { Store, bindActionCreators } from 'redux';
 
-import { Router } from './typeUtils';
+import { Router } from './utilityTypes';
 
 const NAVIGATION_ACTION_CREATORS = {
   push: FarceActions.push,

--- a/src/foundReducer.ts
+++ b/src/foundReducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 
 import ActionTypes from './ActionTypes';
-import { FoundState } from './typeUtils';
+import { FoundState } from './utilityTypes';
 
 // TODO: Re-check types here.
 const foundReducer = (

--- a/src/getRenderArgs.ts
+++ b/src/getRenderArgs.ts
@@ -1,5 +1,5 @@
 import resolveRenderArgs, { ResolveRender } from './resolveRenderArgs';
-import { Router } from './typeUtils';
+import { Router } from './utilityTypes';
 
 export default async function getRenderArgs(
   router: Router,

--- a/src/getStoreRenderArgs.ts
+++ b/src/getStoreRenderArgs.ts
@@ -1,6 +1,16 @@
+import { Store } from 'redux';
+
+import { RenderArgs } from './ElementsRenderer';
 import createStoreRouterObject from './createStoreRouterObject';
 import getRenderArgs from './getRenderArgs';
-import { GetStoreRenderArgsOptions, RenderArgs } from './typeUtils';
+import { FoundState, Resolver } from './typeUtils';
+
+export interface GetStoreRenderArgsOptions {
+  store: Store;
+  getFound?: (store: Store) => FoundState;
+  matchContext: any;
+  resolver: Resolver;
+}
 
 // This function returns a promise. It doesn't need to be an async function
 // because it doesn't use the promise's value.

--- a/src/getStoreRenderArgs.ts
+++ b/src/getStoreRenderArgs.ts
@@ -3,7 +3,7 @@ import { Store } from 'redux';
 import { RenderArgs } from './ElementsRenderer';
 import createStoreRouterObject from './createStoreRouterObject';
 import getRenderArgs from './getRenderArgs';
-import { FoundState, Resolver } from './typeUtils';
+import { FoundState, Resolver } from './utilityTypes';
 
 export interface GetStoreRenderArgsOptions {
   store: Store;

--- a/src/hotRouteConfig.ts
+++ b/src/hotRouteConfig.ts
@@ -1,4 +1,4 @@
-import { RouteConfig } from './typeUtils';
+import { RouteConfig } from './utilityTypes';
 
 export default function hotRouteConfig(routeConfig: RouteConfig): RouteConfig {
   if (__DEV__ && typeof window !== 'undefined') {

--- a/src/makeRouteConfig.ts
+++ b/src/makeRouteConfig.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { RouteConfig } from './typeUtils';
+import { RouteConfig } from './utilityTypes';
 
 // TODO: what is even happening in this file? Try to fix as any's(+ maybe simplify)
 function buildRouteConfig(

--- a/src/resolveRenderArgs.ts
+++ b/src/resolveRenderArgs.ts
@@ -1,13 +1,17 @@
 import HttpError from './HttpError';
 import {
   Match,
-  RenderArgsElements,
   ResolvedElement,
   Resolver,
   RouteIndices,
   RouteObject,
   Router,
 } from './typeUtils';
+
+// This is the folded resolver output from resolveRenderArgs.
+export type RenderArgsElements = Array<
+  ResolvedElement | Record<string, ResolvedElement[]>
+>;
 
 function foldElements(
   elementsRaw: Array<ResolvedElement>,

--- a/src/resolveRenderArgs.ts
+++ b/src/resolveRenderArgs.ts
@@ -6,7 +6,7 @@ import {
   RouteIndices,
   RouteObject,
   Router,
-} from './typeUtils';
+} from './utilityTypes';
 
 // This is the folded resolver output from resolveRenderArgs.
 export type RenderArgsElements = Array<

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -14,7 +14,7 @@ import {
   ResolvedElement,
   RouteMatch,
   RouteObjectBase,
-} from './typeUtils';
+} from './utilityTypes';
 
 function getRouteGetData(route: RouteObjectBase) {
   return route.getData;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -2,13 +2,15 @@ import FarceActions from 'farce/Actions';
 import ServerProtocol from 'farce/ServerProtocol';
 import React, { useMemo } from 'react';
 
+import { RenderArgs } from './ElementsRenderer';
 import RedirectException from './RedirectException';
 import RouterContext from './RouterContext';
+import { FarceRouterOptions } from './createFarceRouter';
 import createFarceStore from './createFarceStore';
 import createRender from './createRender';
 import getStoreRenderArgs from './getStoreRenderArgs';
 import defaultResolver from './resolver';
-import { FarceRouterOptions, RenderArgs, Resolver } from './typeUtils';
+import { Resolver } from './typeUtils';
 
 interface RouterProviderProps {
   renderArgs: RenderArgs;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -10,7 +10,7 @@ import createFarceStore from './createFarceStore';
 import createRender from './createRender';
 import getStoreRenderArgs from './getStoreRenderArgs';
 import defaultResolver from './resolver';
-import { Resolver } from './typeUtils';
+import { Resolver } from './utilityTypes';
 
 interface RouterProviderProps {
   renderArgs: RenderArgs;

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -3,14 +3,12 @@
 
 import {
   FarceStoreExtension,
-  HistoryEnhancerOptions,
   Location,
   LocationDescriptor,
   LocationDescriptorObject,
   NavigationListener,
   NavigationListenerOptions,
   NavigationListenerResult,
-  Protocol,
   Query,
   QueryDescriptor,
 } from 'farce';
@@ -18,7 +16,6 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Middleware, Reducer, Store, StoreEnhancer } from 'redux';
 
-import HttpError from './HttpError';
 import Matcher from './Matcher';
 
 export {
@@ -462,112 +459,27 @@ export interface FoundStoreExtension {
 //   matcher: Matcher,
 // ): StoreEnhancer<{ found: FoundStoreExtension }>;
 
-export type RenderPendingArgs = Match;
-
-// This is the folded resolver output from resolveRenderArgs.
-export type RenderArgsElements = Array<
-  ResolvedElement | Record<string, ResolvedElement[]>
->;
-
-export interface RenderReadyArgs extends Match {
-  elements: RenderArgsElements;
-}
-
-export interface RenderErrorArgs extends Match {
-  error: HttpError;
-}
-
-export type RenderArgs = RenderPendingArgs | RenderReadyArgs | RenderErrorArgs;
-
-export interface CreateRenderOptions {
-  renderPending?: (args: RenderPendingArgs) => React.ReactElement;
-  renderReady?: (args: RenderReadyArgs) => React.ReactElement;
-  renderError?: (args: RenderErrorArgs) => React.ReactNode;
-}
-
 // export function createRender(
 //   options: CreateRenderOptions,
 // ): (renderArgs: RenderArgs) => React.ReactElement;
-
-export interface ConnectedRouterOptions extends CreateRenderOptions {
-  render?: (args: RenderArgs) => React.ReactElement;
-  getFound?: (store: Store) => FoundState;
-}
-
-export interface ConnectedRouterProps {
-  matchContext?: any;
-  resolver: Resolver;
-  initialRenderArgs?: RenderArgs;
-}
-
-export type ConnectedRouter = React.ComponentType<ConnectedRouterProps>;
 
 // export function createConnectedRouter(
 //   options: ConnectedRouterOptions,
 // ): ConnectedRouter;
 
-export interface FarceRouterOptions extends ConnectedRouterOptions {
-  store?: Store;
-  historyProtocol: Protocol;
-  historyMiddlewares?: Middleware[];
-  historyOptions?: Omit<HistoryEnhancerOptions, 'protocol' | 'middlewares'>;
-  routeConfig: RouteConfig;
-}
-
-export type FarceRouterProps = ConnectedRouterProps;
-
-export type FarceRouter = React.ComponentType<FarceRouterProps>;
-
 // export function createFarceRouter(options: FarceRouterOptions): FarceRouter;
-
-export interface BrowserRouterOptions
-  extends Omit<FarceRouterOptions, 'historyProtocol'> {
-  render?: (args: RenderArgs) => React.ReactElement;
-}
-
-export interface BrowserRouterProps
-  extends Omit<FarceRouterProps, 'resolver'> {
-  resolver?: Resolver;
-}
-
-export type BrowserRouter = React.ComponentType<BrowserRouterProps>;
 
 // export function createBrowserRouter(
 //   options: BrowserRouterOptions,
 // ): BrowserRouter;
 
-export interface InitialFarceRouterOptions
-  extends Omit<FarceRouterOptions, 'store'> {
-  matchContext?: any;
-  resolver: Resolver;
-}
-
 // export function createInitialFarceRouter(
 //   options: InitialFarceRouterOptions,
 // ): Promise<FarceRouter>;
 
-export type InitialBrowserRouterOptions = Omit<
-  InitialFarceRouterOptions,
-  'resolver' | 'historyProtocol'
->;
-
 // export function createInitialBrowserRouter(
 //   options: InitialBrowserRouterOptions,
 // ): Promise<BrowserRouter>;
-
-export interface ElementsRendererProps {
-  elements: RenderArgsElements;
-}
-
-export type ElementsRenderer =
-  React.ComponentType<ElementsRendererProps> | null;
-
-export interface GetStoreRenderArgsOptions {
-  store: Store;
-  getFound?: (store: Store) => FoundState;
-  matchContext: any;
-  resolver: Resolver;
-}
 
 // export function getStoreRenderArgs(
 //   options: GetStoreRenderArgsOptions,

--- a/src/useMatch.ts
+++ b/src/useMatch.ts
@@ -1,5 +1,5 @@
-import { Match } from './typeUtils';
 import useRouter from './useRouter';
+import { Match } from './utilityTypes';
 
 /** Returns the current route Match */
 export default function useMatch<TContext = any>(): Match<TContext> | null {

--- a/src/useParams.ts
+++ b/src/useParams.ts
@@ -1,5 +1,5 @@
-import { Params } from './typeUtils';
 import useMatch from './useMatch';
+import { Params } from './utilityTypes';
 
 /** Returns the current route params */
 export default function useParams(): Params | undefined {

--- a/src/utilityTypes.ts
+++ b/src/utilityTypes.ts
@@ -303,92 +303,9 @@ export interface RouteProps extends RouteObjectBase {
 //   constructor(status: number, data?: any);
 // }
 
-export interface RedirectOptions {
-  from?: string;
-  to: string | ((match: Match) => LocationDescriptor);
-  status?: number;
-}
-
-// It's more "natural" to call this "props" when used in the context of a
-//  React component.
-export type RedirectProps = RedirectOptions;
-
 // export class Redirect extends React.Component<RedirectProps> {
 //   constructor(config: RedirectOptions);
 // }
-
-export interface LinkPropsCommon {
-  to: LocationDescriptor;
-  // match: Match,  provided by withRouter
-  // router: Router, provided by withRouter
-  exact?: boolean;
-  target?: string;
-  onClick?: (event: React.SyntheticEvent<any>) => void;
-}
-
-export interface LinkInjectedProps {
-  href: string;
-  onClick: (event: React.SyntheticEvent<any>) => void;
-}
-
-export interface LinkPropsNodeChild extends LinkPropsCommon {
-  activeClassName?: string;
-  activeStyle?: Record<string, unknown>;
-  children?: React.ReactNode;
-}
-
-type ReplaceLinkProps<TInner extends React.ElementType, TProps> = Omit<
-  React.ComponentProps<TInner>,
-  keyof TProps | keyof LinkInjectedProps
-> &
-  TProps;
-
-export type LinkPropsSimple = ReplaceLinkProps<'a', LinkPropsNodeChild>;
-
-export type LinkPropsWithAs<
-  TInner extends React.ElementType<LinkInjectedProps>,
-> = ReplaceLinkProps<
-  TInner,
-  LinkPropsNodeChild & {
-    as: TInner;
-    activePropName?: null;
-  }
->;
-
-export type LinkPropsWithActivePropName<
-  TInner extends React.ComponentType<
-    LinkInjectedProps & { [activePropName in TActivePropName]: boolean }
-  >,
-  TActivePropName extends string,
-> = ReplaceLinkProps<
-  TInner,
-  LinkPropsNodeChild & {
-    as: TInner;
-    activePropName: TActivePropName;
-  } & {
-    [activePropName in TActivePropName]?: null;
-  }
->;
-
-export interface LinkPropsWithFunctionChild extends LinkPropsCommon {
-  children: (linkRenderArgs: {
-    href: string;
-    active: boolean;
-    onClick: (event: React.SyntheticEvent<any>) => void;
-  }) => React.ReactNode;
-}
-
-export type LinkProps<
-  TInner extends React.ElementType = never,
-  TInnerWithActivePropName extends React.ComponentType<
-    LinkInjectedProps & { [activePropName in TActivePropName]: boolean }
-  > = never,
-  TActivePropName extends string = never,
-> =
-  | LinkPropsSimple
-  | LinkPropsWithAs<TInner>
-  | LinkPropsWithActivePropName<TInnerWithActivePropName, TActivePropName>
-  | LinkPropsWithFunctionChild;
 
 // export class Link<
 //   TInner extends React.ElementType = never,

--- a/src/utilityTypes.ts
+++ b/src/utilityTypes.ts
@@ -93,49 +93,14 @@ export interface Resolver {
   ): AsyncGenerator<Array<ResolvedElement> | undefined>;
 }
 
-// export const resolver: Resolver;
-
 export interface FoundState {
   match: MatchBase;
   resolvedMatch: MatchBase;
 }
 
-// export const foundReducer: Reducer<FoundState>;
-
 export interface IsActiveOptions {
   exact?: boolean;
 }
-
-/**
- * An object implementing the matching algorithm.
- *
- * User code generally shouldn't need this, but it doesn't hurt to here,
- * since we use it for routerShape below.
- */
-// export class Matcher {
-//   constructor(routeConfig: RouteConfig);
-
-//   match(location: Location): MatcherResult | null;
-
-//   getRoutes: (match: MatchBase) => RouteObject[];
-
-//   /**
-//    * for match as above, returns whether match corresponds to location or a
-//    * subpath of location; if exact is set, returns whether match corresponds
-//    * exactly to location
-//    */
-//   isActive: (
-//     match: Match,
-//     location: LocationDescriptorObject,
-//     options?: IsActiveOptions,
-//   ) => boolean;
-
-//   /**
-//    * Returns the path string for a pattern of the same format as a route path
-//    * and a object of the corresponding path parameters
-//    */
-//   format: (pattern: string, params: ParamsDescriptor) => string;
-// }
 
 export interface Router extends FarceStoreExtension, FoundStoreExtension {
   /**
@@ -282,43 +247,6 @@ export interface RouteObject extends RouteObjectBase {
 
 export type RouteConfig = RouteObject[];
 
-export interface RouteProps extends RouteObjectBase {
-  children?: React.ReactNode | Record<string, React.ReactNode>;
-}
-
-/**
- * JSX Route
- */
-// export class Route extends React.Component<RouteProps> {
-//   constructor(options: RouteObject | RouteProps);
-// }
-
-// export function hotRouteConfig(routeConfig: RouteConfig): RouteConfig;
-
-// export class HttpError {
-//   status: number;
-
-//   data: any;
-
-//   constructor(status: number, data?: any);
-// }
-
-// export class Redirect extends React.Component<RedirectProps> {
-//   constructor(config: RedirectOptions);
-// }
-
-// export class Link<
-//   TInner extends React.ElementType = never,
-//   TInnerWithActivePropName extends React.ComponentType<
-//     LinkInjectedProps & { [activePropName in TActivePropName]: boolean }
-//   > = never,
-//   TActivePropName extends string = never,
-// > extends React.Component<
-//   LinkProps<TInner, TInnerWithActivePropName, TActivePropName>
-// > {
-//   props: LinkProps<TInner, TInnerWithActivePropName, TActivePropName>;
-// }
-
 export interface RouterState<TContext = any> {
   match: Match<TContext>;
   router: Router;
@@ -336,68 +264,7 @@ export interface RouteComponentDataProps<T, TContext = never>
   data: T;
 }
 
-/**
- * Returns the Router and current route match from context
- */
-// export function useRouter<TContext = any>(): RouterState<TContext>;
-
-/** Returns the current route Match */
-// export function useMatch<TContext = any>(): Match<TContext>;
-
-/** Returns the current route params */
-// export function useParams(): Params;
-
-/** Returns the current location object */
-// export function useLocation(): Location;
-
-// export function withRouter<TProps extends RouterState>(
-//   Component: React.ComponentType<TProps>,
-// ): React.ComponentType<Omit<TProps, keyof RouterState>>;
-
-// export class RedirectException {
-//   constructor(location: LocationDescriptor, status?: number);
-
-//   location: LocationDescriptor;
-
-//   status: number;
-// }
-
-/**
- * Create a route configuration from JSX configuration elements.
- */
-// export function makeRouteConfig(node: React.ReactNode): RouteConfig;
-
 export interface FoundStoreExtension {
   matcher: Matcher;
   replaceRouteConfig: (routeConfig: RouteConfig) => void;
 }
-
-// export function createMatchEnhancer(
-//   matcher: Matcher,
-// ): StoreEnhancer<{ found: FoundStoreExtension }>;
-
-// export function createRender(
-//   options: CreateRenderOptions,
-// ): (renderArgs: RenderArgs) => React.ReactElement;
-
-// export function createConnectedRouter(
-//   options: ConnectedRouterOptions,
-// ): ConnectedRouter;
-
-// export function createFarceRouter(options: FarceRouterOptions): FarceRouter;
-
-// export function createBrowserRouter(
-//   options: BrowserRouterOptions,
-// ): BrowserRouter;
-
-// export function createInitialFarceRouter(
-//   options: InitialFarceRouterOptions,
-// ): Promise<FarceRouter>;
-
-// export function createInitialBrowserRouter(
-//   options: InitialBrowserRouterOptions,
-// ): Promise<BrowserRouter>;
-
-// export function getStoreRenderArgs(
-//   options: GetStoreRenderArgsOptions,
-// ): Promise<RenderArgs>;

--- a/test/Matcher.test.ts
+++ b/test/Matcher.test.ts
@@ -1,5 +1,5 @@
 import Matcher from '../src/Matcher';
-import { Match } from '../src/typeUtils';
+import { Match } from '../src/utilityTypes';
 
 const createLocationMatch = (locationMatch) =>
   ({

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
 import createFarceRouter from '../src/createFarceRouter';
-import { RouteRenderMethod } from '../src/typeUtils';
+import { RouteRenderMethod } from '../src/utilityTypes';
 import { InstrumentedResolver } from './helpers';
 
 describe('render', () => {

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -3,7 +3,7 @@ import pDefer from 'p-defer';
 
 import { getRouteMatches } from '../src/ResolverUtils';
 import resolver from '../src/resolver';
-import { Match } from '../src/typeUtils';
+import { Match } from '../src/utilityTypes';
 
 describe('resolver', () => {
   describe('getData', () => {


### PR DESCRIPTION
Based on #1038, will merge it after it. This doesn't change anything, only decouples some types into their files, so they are not all crammed into `typeUtils.ts`. I think at some point I'd want to re-write class into function components and make some breaking changes to keep the types tidier. 