### PR TITLE
Fix Param types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release": "4c release --conventional-commits",
     "tdd": "jest --watch",
     "test": "yarn lint && yarn test:ts && yarn testonly -- --coverage",
-    "test:ts": "dtslint --expectOnly types && yarn tsc --noEmit",
+    "test:ts": "dtslint --expectOnly types && yarn tsc --noEmit && yarn tsc --noEmit -p test",
     "testonly": "jest --runInBand --verbose",
     "docs": "yarn --cwd www start"
   },

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -39,11 +39,11 @@ type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 //   RESOLVE_MATCH: '@@found/RESOLVE_MATCH';
 // };
 
-export type Params = Record<string, string>;
+export type Params = Record<string, string | undefined>;
 
 export type ParamsDescriptor = Record<
   string,
-  string | number | boolean | Record<string, unknown>
+  string | number | boolean | Record<string, unknown> | undefined
 >;
 
 // These need to be interfaces to avoid circular reference issues.

--- a/test/Matcher.test.ts
+++ b/test/Matcher.test.ts
@@ -223,8 +223,7 @@ describe('Matcher', () => {
       const missingMatch = matcher.match({ pathname: '/a' });
 
       if (missingMatch != null && 0 in missingMatch.params) {
-        // FIXME: This type is wrong. It should be string | undefined.
-        const param: string = missingMatch.params[0];
+        const param: string | undefined = missingMatch.params[0];
         expect(param).toBeUndefined();
       }
 

--- a/test/Matcher.test.ts
+++ b/test/Matcher.test.ts
@@ -1,4 +1,9 @@
 import Matcher from '../src/Matcher';
+import {
+  type IsActiveOptions,
+  type LocationDescriptorObject,
+  Match,
+} from '../src/typeUtils';
 
 describe('Matcher', () => {
   describe('route hierarchies', () => {
@@ -32,11 +37,11 @@ describe('Matcher', () => {
       ['nested matching', '/foo/bar', [0, 1]],
       ['route fallthrough', '/foo/baz', [2]],
     ].forEach(([scenario, pathname, expectedRouteIndices]) => {
-      describe(scenario, () => {
+      describe(scenario as string, () => {
         it('should be supported', () => {
           expect(
             matcher.match({
-              pathname,
+              pathname: pathname as string,
             }),
           ).toMatchObject({
             routeIndices: expectedRouteIndices,
@@ -265,7 +270,7 @@ describe('Matcher', () => {
       it(`should match ${scenario}`, () => {
         expect(
           matcher.match({
-            pathname,
+            pathname: pathname as string,
           }),
         ).toMatchObject({
           routeIndices: expectedRouteIndices,
@@ -350,7 +355,7 @@ describe('Matcher', () => {
   });
 
   describe('#joinPaths', () => {
-    const matcher = new Matcher();
+    const matcher = new Matcher([]);
 
     [
       ['no extra slashes', '/foo', 'bar'],
@@ -359,6 +364,7 @@ describe('Matcher', () => {
       ['slashes everywhere', '/foo/', '/bar'],
     ].forEach(([scenario, basePath, path]) => {
       it(`should support ${scenario}`, () => {
+        // @ts-ignore
         expect(matcher.joinPaths(basePath, path)).toBe('/foo/bar');
       });
     });
@@ -415,7 +421,11 @@ describe('Matcher', () => {
       ].forEach(([scenario, matchLocation, location, options]) => {
         it(`should be active on ${scenario}`, () => {
           expect(
-            matcher.isActive({ location: matchLocation }, location, options),
+            matcher.isActive(
+              { location: matchLocation } as any as Match,
+              location as LocationDescriptorObject,
+              options as IsActiveOptions,
+            ),
           ).toBe(true);
         });
       });
@@ -459,7 +469,11 @@ describe('Matcher', () => {
       ].forEach(([scenario, matchLocation, location, options]) => {
         it(`should not be active on ${scenario}`, () => {
           expect(
-            matcher.isActive({ location: matchLocation }, location, options),
+            matcher.isActive(
+              { location: matchLocation } as any as Match,
+              location as LocationDescriptorObject,
+              options as IsActiveOptions,
+            ),
           ).toBe(false);
         });
       });

--- a/test/Matcher.test.ts
+++ b/test/Matcher.test.ts
@@ -220,11 +220,15 @@ describe('Matcher', () => {
         },
       ]);
 
-      expect(
-        matcher.match({
-          pathname: '/a',
-        }),
-      ).toEqual({
+      const missingMatch = matcher.match({ pathname: '/a' });
+
+      if (missingMatch != null && 0 in missingMatch.params) {
+        // FIXME: This type is wrong. It should be string | undefined.
+        const param: string = missingMatch.params[0];
+        expect(param).toBeUndefined();
+      }
+
+      expect(missingMatch).toEqual({
         routeIndices: [0, 0],
         routeParams: [{ foo: 'a' }, { 0: undefined }],
         params: {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Fixes #1057

I'm not sure if this is the idea solution. It maintains the same runtime behaviour but of course there is a breaking change in the types. Alternatively we could keep the types and change the behaviour so that missing params are not present in the object.